### PR TITLE
Add Aurora Global Database cluster CloudFormation template

### DIFF
--- a/state/rds-aurora-global-cluster.yaml
+++ b/state/rds-aurora-global-cluster.yaml
@@ -1,0 +1,178 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: >-
+  Aurora Global Database cluster. Creates an AWS::RDS::GlobalCluster resource
+  and exports its identifier for use with rds-aurora stacks. That identifier
+  can be passed as the GlobalClusterIdentifier property in
+  widdix/aws-cf-templates rds-aurora.yaml DBCluster resources in secondary
+  regions.
+
+# ---------------------------------------------------------------------------
+# Usage
+# ---------------------------------------------------------------------------
+# 1. Deploy a widdix rds-aurora stack in the PRIMARY region first, without
+#    GlobalClusterIdentifier on the AWS::RDS::DBCluster resource.
+#
+# 2. Deploy this stack and set:
+#      SourceDBClusterIdentifier: <ARN of the primary DB cluster>
+#    This creates the AWS::RDS::GlobalCluster and attaches the existing
+#    primary DB cluster as the writer cluster.
+#
+# 3. Deploy a widdix rds-aurora stack in each SECONDARY region,
+#    passing:
+#      GlobalClusterIdentifier: <global-cluster-identifier>
+#    to the AWS::RDS::DBCluster Properties block.
+#
+# 4. For SECONDARY region stacks, do not set MasterUsername or
+#    MasterUserPassword on AWS::RDS::DBCluster; those are inherited from
+#    the primary cluster.
+#
+# Notes:
+# - Engine / EngineVersion values here should match the engine/version used by
+#   the primary rds-aurora stack.
+# - If SourceDBClusterIdentifier is provided, this template inherits engine,
+#   engine version, and storage encryption settings from the source cluster.
+# ---------------------------------------------------------------------------
+
+Parameters:
+
+  GlobalClusterIdentifier:
+    Type: String
+    Description: >-
+      Identifier for the Aurora global database cluster. Must be unique within
+      your AWS account. Used as the GlobalClusterIdentifier in rds-aurora stacks.
+    MinLength: 1
+    MaxLength: 63
+    AllowedPattern: '^[a-zA-Z]{1}(?:-?[a-zA-Z0-9]){0,62}$'
+    ConstraintDescription: >-
+      Must begin with a letter, contain only alphanumeric characters and
+      hyphens, and not end with a hyphen.
+
+  Engine:
+    Type: String
+    Description: >-
+      Aurora engine. Required when SourceDBClusterIdentifier is not set;
+      ignored otherwise.
+    AllowedValues:
+      - ''
+      - 'aurora-mysql'
+      - 'aurora-postgresql'
+    Default: ''
+
+  EngineVersion:
+    Type: String
+    Description: >-
+      Aurora engine version (e.g. 17.7 for aurora-postgresql, 8.0.mysql_aurora.3.03.0
+      for aurora-mysql). Optional; omit to let AWS select the default for the engine.
+      Ignored when SourceDBClusterIdentifier is set.
+    Default: ''
+
+  SourceDBClusterIdentifier:
+    Type: String
+    Default: ''
+    Description: >-
+      Optional. ARN of an existing Aurora DB cluster to promote as the primary
+      of this global cluster. When provided, Engine/EngineVersion and
+      StorageEncrypted are inherited from the source cluster and their
+      parameters here are ignored.
+
+  DeletionProtection:
+    Type: String
+    AllowedValues: ['true', 'false']
+    Default: 'false'
+    Description: >-
+      Enable deletion protection on the global cluster. Note: all member
+      clusters must be detached before the global cluster can be deleted
+      regardless of this setting.
+
+# ---------------------------------------------------------------------------
+# Conditions
+# ---------------------------------------------------------------------------
+
+Conditions:
+
+  HasSourceDBCluster: !Not [!Equals [!Ref SourceDBClusterIdentifier, '']]
+  HasEngineVersion: !Not [!Equals [!Ref EngineVersion, '']]
+
+# ---------------------------------------------------------------------------
+# Rules
+# https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/rules-section-structure.html
+# ---------------------------------------------------------------------------
+
+Rules:
+
+  EngineParametersRequiredForNewCluster:
+    RuleCondition: !Equals [!Ref SourceDBClusterIdentifier, '']
+    Assertions:
+      - Assert: !Not [!Equals [!Ref Engine, '']]
+        AssertDescription: >-
+          Engine is required when SourceDBClusterIdentifier is not set.
+      - Assert: !Not [!Equals [!Ref EngineVersion, '']]
+        AssertDescription: >-
+          EngineVersion is required when SourceDBClusterIdentifier is not set.
+
+# ---------------------------------------------------------------------------
+# Resources
+# ---------------------------------------------------------------------------
+
+Resources:
+
+  GlobalCluster:
+    # DeletionPolicy: Delete is intentional — CloudFormation will fail to
+    # delete the global cluster if member clusters are still attached, which
+    # protects against accidental data loss. Change to Retain if you manage
+    # the lifecycle outside of CloudFormation.
+    DeletionPolicy: Delete
+    UpdateReplacePolicy: Delete
+    Type: 'AWS::RDS::GlobalCluster'
+    # cfn-lint has a oneOf schema requiring either Engine or SourceDBClusterIdentifier
+    # but not both. The conditional approach with AWS::NoValue is valid CloudFormation
+    # but cfn-lint cannot resolve conditions statically.
+    Metadata:
+      cfn-lint:
+        config:
+          ignore_checks:
+            - E3003
+            - E3018
+    Properties:
+      GlobalClusterIdentifier: !Ref GlobalClusterIdentifier
+      DeletionProtection: !Ref DeletionProtection
+      Engine: !If
+        - HasSourceDBCluster
+        - !Ref 'AWS::NoValue'
+        - !Ref Engine
+      EngineVersion: !If
+        - HasSourceDBCluster
+        - !Ref 'AWS::NoValue'
+        - !If [HasEngineVersion, !Ref EngineVersion, !Ref 'AWS::NoValue']
+      StorageEncrypted: !If
+        - HasSourceDBCluster
+        - !Ref 'AWS::NoValue'
+        - true
+      SourceDBClusterIdentifier: !If
+        - HasSourceDBCluster
+        - !Ref SourceDBClusterIdentifier
+        - !Ref 'AWS::NoValue'
+
+# ---------------------------------------------------------------------------
+# Outputs
+# ---------------------------------------------------------------------------
+
+Outputs:
+
+  TemplateID:
+    Description: 'Template ID.'
+    Value: 'state/aurora-global-cluster'
+
+  StackName:
+    Description: 'Stack name.'
+    Value: !Sub '${AWS::StackName}'
+
+  GlobalClusterIdentifier:
+    Description: >-
+      The global cluster identifier. Pass this as the GlobalClusterIdentifier
+      property on the AWS::RDS::DBCluster resource in secondary-region
+      rds-aurora stacks. The primary cluster is attached by creating this
+      global cluster with SourceDBClusterIdentifier.
+    Value: !Ref GlobalCluster
+    Export:
+      Name: !Sub '${AWS::StackName}-GlobalClusterIdentifier'

--- a/state/rds-aurora.yaml
+++ b/state/rds-aurora.yaml
@@ -102,6 +102,15 @@ Parameters:
     - 'aurora'
     - 'aurora-iopt1'
     Default: 'aurora'
+  GlobalClusterIdentifier:
+    Description: 'Optional identifier of an AWS::RDS::GlobalCluster to attach this cluster to as a secondary member. Leave blank for primary members and for standalone clusters.'
+    Type: String
+    Default: ''
+  EnableGlobalWriteForwarding:
+    Description: 'Enable this secondary DB cluster to forward write operations to the primary cluster of the global database. Only applicable when GlobalClusterIdentifier is set.'
+    Type: String
+    AllowedValues: ['true', 'false']
+    Default: 'false'
   DBSnapshotIdentifier:
     Description: 'Optional identifier for the DB cluster snapshot from which you want to restore (leave blank to create an empty cluster).'
     Type: String
@@ -302,11 +311,13 @@ Conditions:
   HasAlertTopic: !Not [!Equals [!Ref ParentAlertStack, '']]
   HasDBSnapshotIdentifier: !Not [!Equals [!Ref DBSnapshotIdentifier, '']]
   HasKmsKeyAndNotDBSnapshotIdentifier: !And [!Condition HasKmsKey, !Not [!Condition HasDBSnapshotIdentifier]]
+  HasNotGlobalClusterAndNotDBSnapshotIdentifier: !And [!Not [!Condition HasGlobalCluster], !Not [!Condition HasDBSnapshotIdentifier]]
   HasEngineMySQL: !Equals [!FindInMap [EngineMap, !Ref Engine, Engine], 'aurora-mysql']
   HasPerformanceInsights: !Equals [!Ref EnablePerformanceInsights, 'true']
   HasEnhancedMonitoring: !Not [!Equals [!Ref MonitoringInterval, 0]]
   HasDBClusterParameterGroup: !Not [!Equals [!Ref DBClusterParameterGroupName, '']]
   HasDBParameterGroup: !Not [!Equals [!Ref DBParameterGroupName, '']]
+  HasGlobalCluster: !Not [!Equals [!Ref GlobalClusterIdentifier, '']]
 Resources:
   SecretTargetAttachment:
     Condition: HasSecret
@@ -388,21 +399,24 @@ Resources:
     Properties:
       BackupRetentionPeriod: !Ref DBBackupRetentionPeriod
       CopyTagsToSnapshot: true
-      DatabaseName: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBName]
+      DatabaseName: !If [HasNotGlobalClusterAndNotDBSnapshotIdentifier, !Ref DBName, !Ref 'AWS::NoValue']
       DBClusterParameterGroupName: !If [HasDBClusterParameterGroup, !Ref DBClusterParameterGroupName, !Ref DBClusterParameterGroup]
       DBSubnetGroupName: !Ref DBSubnetGroup
       Engine: !FindInMap [EngineMap, !Ref Engine, Engine]
-      EngineMode: provisioned
-      EngineVersion: !FindInMap [EngineMap, !Ref Engine, EngineVersion]
+      EngineMode: !If [HasGlobalCluster, !Ref 'AWS::NoValue', provisioned]
+      EngineVersion: !If [HasGlobalCluster, !Ref 'AWS::NoValue', !FindInMap [EngineMap, !Ref Engine, EngineVersion]]
       KmsKeyId: !If [HasKmsKeyAndNotDBSnapshotIdentifier, {'Fn::ImportValue': !Sub '${ParentKmsKeyStack}-KeyId'}, !Ref 'AWS::NoValue']
-      MasterUsername: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !Ref DBMasterUsername]
+      MasterUsername: !If [HasNotGlobalClusterAndNotDBSnapshotIdentifier, !Ref DBMasterUsername, !Ref 'AWS::NoValue']
       MasterUserPassword: !If
-      - HasDBSnapshotIdentifier
+      - HasGlobalCluster
       - !Ref 'AWS::NoValue'
       - !If
-        - HasSecret
-        - !Join ['', ['{{resolve:secretsmanager:', {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}, ':SecretString:password}}']]
-        - !Sub "${DBMasterUserPassword}"  # https://github.com/aws-cloudformation/cfn-lint/issues/3418#issuecomment-2192228851
+        - HasDBSnapshotIdentifier
+        - !Ref 'AWS::NoValue'
+        - !If
+          - HasSecret
+          - !Join ['', ['{{resolve:secretsmanager:', {'Fn::ImportValue': !Sub '${ParentSecretStack}-SecretArn'}, ':SecretString:password}}']]
+          - !Sub "${DBMasterUserPassword}"  # https://github.com/aws-cloudformation/cfn-lint/issues/3418#issuecomment-2192228851
       PerformanceInsightsEnabled: !If [HasPerformanceInsights, !Ref EnablePerformanceInsights, !Ref 'AWS::NoValue']
       PerformanceInsightsRetentionPeriod: !If [HasPerformanceInsights, !Ref PerformanceInsightsRetentionPeriod, !Ref 'AWS::NoValue']
       DatabaseInsightsMode: !Ref DatabaseInsightsMode
@@ -410,7 +424,12 @@ Resources:
       PreferredBackupWindow: !Ref PreferredBackupWindow
       PreferredMaintenanceWindow: !Ref PreferredMaintenanceWindow
       SnapshotIdentifier: !If [HasDBSnapshotIdentifier, !Ref DBSnapshotIdentifier, !Ref 'AWS::NoValue']
-      StorageEncrypted: !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !If [HasKmsKey, true, false]]
+      StorageEncrypted: !If
+      - HasGlobalCluster
+      - !Ref 'AWS::NoValue'
+      - !If [HasDBSnapshotIdentifier, !Ref 'AWS::NoValue', !If [HasKmsKey, true, false]]
+      EnableGlobalWriteForwarding: !If [HasGlobalCluster, !Ref EnableGlobalWriteForwarding, !Ref 'AWS::NoValue']
+      GlobalClusterIdentifier: !If [HasGlobalCluster, !Ref GlobalClusterIdentifier, !Ref 'AWS::NoValue']
       StorageType: !Ref StorageType
       VpcSecurityGroupIds:
       - !Ref ClusterSecurityGroup


### PR DESCRIPTION
Adds state/rds-aurora-global-cluster.yaml to create an AWS::RDS::GlobalCluster and export its identifier. Also adds optional GlobalClusterIdentifier parameter to state/rds-aurora.yaml to attach clusters as secondary members.

Change-type: minor