### PR TITLE
Add SNS topic and S3 bucket exports to cloudtrail stack

### DIFF
--- a/security/cloudtrail.yaml
+++ b/security/cloudtrail.yaml
@@ -699,3 +699,14 @@ Outputs:
   StackName:
     Description: 'Stack name.'
     Value: !Sub '${AWS::StackName}'
+  TrailTopicArn:
+    Description: 'ARN of the SNS topic that CloudTrail publishes notifications to.'
+    Value: !Ref TrailTopic
+    Export:
+      Name: !Sub '${AWS::StackName}-TrailTopicArn'
+  TrailBucketName:
+    Condition: InternalBucket
+    Description: 'Name of the S3 bucket where CloudTrail writes logs.'
+    Value: !Ref TrailBucket
+    Export:
+      Name: !Sub '${AWS::StackName}-TrailBucketName'


### PR DESCRIPTION
Exports TrailTopicArn and TrailBucketName so dependent stacks can reference them via Fn::ImportValue without hardcoding values.

Project: https://balena.fibery.io/Work/Project/Research-Usage-of-SentinelOne-SIEM-Log-Ingesters-for-Log-Anomaly-Detection-2316

Change-type: patch